### PR TITLE
fix: change identifyAuthenticatedUser function signature

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -76,21 +76,13 @@ function sendTrackingLogEvent(eventName, properties) {
 }
 
 /**
- * Send identify call to Segment, using userId from authApiClient.
+ * Send identify call to Segment.
+ * @param userId
  * @param traits (optional)
  */
-function identifyAuthenticatedUser(traits) {
-  const apiClient = getAuthApiClient();
-  const authState = apiClient.getAuthenticationState();
-  const loggingService = getLoggingService(); // verifies configuration early
-  if (authState.authentication && authState.authentication.userId) {
-    // eslint-disable-next-line no-undef
-    window.analytics.identify(authState.authentication.userId, traits);
-    hasIdentifyBeenCalled = true;
-  } else {
-    const details = `authState: ${JSON.stringify(authState)} cookies: ${document.cookie}`;
-    loggingService.logError(`Failed to sendAuthenticatedIdentify. ${details}`);
-  }
+function identifyAuthenticatedUser(userId, traits) {
+  window.analytics.identify(userId, traits);
+  hasIdentifyBeenCalled = true;
 }
 
 /**

--- a/src/analytics.test.js
+++ b/src/analytics.test.js
@@ -36,15 +36,6 @@ function createMockAuthApiClientAuthenticated() {
   };
 }
 
-function createMockAuthApiClientAuthenticationIncomplete() {
-  mockAuthApiClient = {
-    getAuthenticationState:
-      jest.fn(() => ({
-        authentication: {},
-      })),
-  };
-}
-
 function createMockAuthApiClientPostResolved() {
   mockAuthApiClient = {
     post: jest.fn().mockResolvedValue(undefined),
@@ -122,44 +113,14 @@ describe('analytics identifyAuthenticatedUser', () => {
     };
   });
 
-  it('fails when loggingService is not configured', () => {
-    mockLoggingService = undefined;
-    createMockAuthApiClientAuthenticated();
-    configureAnalyticsWithMocks();
-
-    expect(() => identifyAuthenticatedUser())
-      .toThrowError('You must configure the loggingService.');
-  });
-
-  it('fails when authApiClient is not configured', () => {
-    createMockLoggingService();
-    mockAuthApiClient = undefined;
-    configureAnalyticsWithMocks();
-
-    expect(() => identifyAuthenticatedUser())
-      .toThrowError('You must configure the authApiClient.');
-  });
-
   it('calls Segment identify on success', () => {
-    createMockLoggingService();
-    createMockAuthApiClientAuthenticated();
     configureAnalyticsWithMocks();
 
     const testTraits = { anything: 'Yay!' };
-    identifyAuthenticatedUser(testTraits);
+    identifyAuthenticatedUser(testUserId, testTraits);
 
     expect(window.analytics.identify.mock.calls.length).toBe(1);
     expect(window.analytics.identify).toBeCalledWith(testUserId, testTraits);
-  });
-
-  it('logs error when authentication problem.', () => {
-    createMockLoggingService();
-    createMockAuthApiClientAuthenticationIncomplete();
-    configureAnalyticsWithMocks();
-
-    identifyAuthenticatedUser();
-
-    expect(mockLoggingService.logError.mock.calls.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
BREAKING CHANGE: userId is now a required parameter of the identifyAuthenticatedUser function