### PR TITLE
fix: userId required for identifyAuthenticatedUser

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -24,14 +24,14 @@ function getTrackingLogApiBaseUrl() {
 
 function getAuthApiClient() {
   if (!config.authApiClient) {
-    throw Error('You must configure the authApiClient.');
+    throw new Error('You must configure the authApiClient.');
   }
   return config.authApiClient;
 }
 
 function getLoggingService() {
   if (!config.loggingService) {
-    throw Error('You must configure the loggingService.');
+    throw new Error('You must configure the loggingService.');
   }
   return config.loggingService;
 }
@@ -81,6 +81,9 @@ function sendTrackingLogEvent(eventName, properties) {
  * @param traits (optional)
  */
 function identifyAuthenticatedUser(userId, traits) {
+  if (!userId) {
+    throw new Error('UserId is required for identifyAuthenticatedUser.');
+  }
   window.analytics.identify(userId, traits);
   hasIdentifyBeenCalled = true;
 }

--- a/src/analytics.test.js
+++ b/src/analytics.test.js
@@ -122,6 +122,13 @@ describe('analytics identifyAuthenticatedUser', () => {
     expect(window.analytics.identify.mock.calls.length).toBe(1);
     expect(window.analytics.identify).toBeCalledWith(testUserId, testTraits);
   });
+
+  it('throws error if userId is not supplied', () => {
+    configureAnalyticsWithMocks();
+
+    expect(() => identifyAuthenticatedUser(null))
+      .toThrowError(new Error('UserId is required for identifyAuthenticatedUser.'));
+  });
 });
 
 describe('analytics identifyAnonymousUser', () => {
@@ -172,7 +179,8 @@ describe('analytics send Page event', () => {
   });
 
   it('calls Segment page on success after identifyAuthenticatedUser', () => {
-    testSendPageAfterIdentify(identifyAuthenticatedUser);
+    const userId = 1;
+    testSendPageAfterIdentify(() => identifyAuthenticatedUser(userId));
   });
 
   it('calls Segment page on success after identifyAnonymousUser', () => {
@@ -222,7 +230,8 @@ describe('analytics send Track event', () => {
   });
 
   it('calls Segment track on success after identifyAuthenticatedUser', () => {
-    testSendTrackEventAfterIdentify(identifyAuthenticatedUser);
+    const userId = 1;
+    testSendTrackEventAfterIdentify(() => identifyAuthenticatedUser(userId));
   });
 
   it('calls Segment track on success after identifyAnonymousUser', () => {


### PR DESCRIPTION
BREAKING CHANGE: UserId is now required for identifyAuthenticatedUser.

This should not require any app changes. If you do need to identify
for an anonymous user, without the userId, use identifyAnonymousUser.

ARCH-948